### PR TITLE
QRリーダーライブラリ変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "register-service-worker": "^1.0.0",
     "uuid": "^3.2.1",
     "vue": "^2.5.16",
-    "vue-qart": "^2.1.1",
     "vue-qrcode-reader": "0.7.1",
     "vue-router": "^3.0.1",
     "vuelidate": "^0.7.4",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clmtrackr": "^1.1.2",
     "d3": "^5.4.0",
     "firebase": "^5.0.4",
+    "qrcode.vue": "^1.6.0",
     "register-service-worker": "^1.0.0",
     "uuid": "^3.2.1",
     "vue": "^2.5.16",

--- a/src/components/Generate.vue
+++ b/src/components/Generate.vue
@@ -13,18 +13,14 @@
       QrcodeVue
     },
     name: "qrGenarate",
-    created() {
-      this.value = this.uuid
-    },
     data() {
       return {
-        value: this.uuid,
         size: 260
       }
     },
     computed: {
       ...mapState('User', {
-        uuid: state => state.uuid,
+        value: state => state.uuid,
       })
     },
   };

--- a/src/components/Generate.vue
+++ b/src/components/Generate.vue
@@ -2,7 +2,7 @@
   <div id="qrGenarate">
   <p>Generate QR code</p>
   <qrcode-vue :value="value" :size="size" level="H"></qrcode-vue>
-  {{ value = `https://example` }}
+  {{ value = uuid }}
   </div>
 </template>
 

--- a/src/components/Generate.vue
+++ b/src/components/Generate.vue
@@ -2,7 +2,6 @@
   <div id="qrGenarate">
   <p>Generate QR code</p>
   <qrcode-vue :value="value" :size="size" level="M"></qrcode-vue>
-  {{ this.uuid }}
   </div>
 </template>
 

--- a/src/components/Generate.vue
+++ b/src/components/Generate.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="qrGenarate">
   <p>Generate QR code</p>
-  <qrcode-vue :value="value" :size="size" level="H"></qrcode-vue>
-  {{ value = uuid }}
+  <qrcode-vue :value="value" :size="size" level="M"></qrcode-vue>
+  {{ this.uuid }}
   </div>
 </template>
 
@@ -14,9 +14,12 @@
       QrcodeVue
     },
     name: "qrGenarate",
+    created() {
+      this.value = this.uuid
+    },
     data() {
       return {
-        value: '',
+        value: this.uuid,
         size: 260
       }
     },

--- a/src/components/Generate.vue
+++ b/src/components/Generate.vue
@@ -1,35 +1,31 @@
 <template>
   <div id="qrGenarate">
   <p>Generate QR code</p>
-  <vue-q-art :config=config></vue-q-art>
-  {{ config.value = `emotion/`+uuid }}
+  <qrcode-vue :value="value" :size="size" level="H"></qrcode-vue>
+  {{ value = `https://example` }}
   </div>
 </template>
 
 <script>
-  import VueQArt from 'vue-qart'
+  import QrcodeVue from 'qrcode.vue';
   import { mapState } from 'vuex'
-
   export default {
-  components: {
-    VueQArt
-  },
-  name: "qrGenarate",
-  data() {
-    return {
-      config: {
-        value: "",
-        imagePath: "/img/tukamoto.jpg",
-        filter: "color"
+    components: {
+      QrcodeVue
+    },
+    name: "qrGenarate",
+    data() {
+      return {
+        value: '',
+        size: 260
       }
-    };
-  },
-  computed: {
-    ...mapState('User', {
-      uuid: state => state.uuid,
-    })
-  },
-};
+    },
+    computed: {
+      ...mapState('User', {
+        uuid: state => state.uuid,
+      })
+    },
+  };
 </script>
 
 <style>

--- a/src/components/Reading.vue
+++ b/src/components/Reading.vue
@@ -47,7 +47,7 @@
       },
       onDecode(content){
         this.paused = true
-        this.$router.push(content)
+        this.$router.push('emotion/' + content)
       }
     }
   }


### PR DESCRIPTION
vue-qartをやめる。
QRサイズを自由に変更するのが大変そう
QR用Image画像が複雑だと認識が悪くなりそうなので
ノーマルなQRリーダーにqrcode.vueに変更

読み取りvalueも``` /emotion/uuid ``` ではなくuuidのみにする



https://www.npmjs.com/package/qrcode.vue
